### PR TITLE
Docker images' names are fixed and don't depend on the project directory

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,12 +2,14 @@ version: '2'
 services:
     back:
         build: back
+        image: workshopstarsconf_back
         volumes:
             - ./back:/src
         ports:
             - 8000:8000
     front:
         build: front
+        image: workshopstarsconf_front
         environment:
             - BACKEND_URL=http://localhost:8000
         volumes:


### PR DESCRIPTION
Para la persona que revise este pull request:
Se debe hacer un `docker-compose up -d`y posteriormente un `docker images`.
Resultado esperado: que `workshopstarsconf_front` y `workshopstarsconf_back` aparezcan en ese listado.